### PR TITLE
Update DuetWebAPI.py for rrf3 check

### DIFF
--- a/DuetWebAPI.py
+++ b/DuetWebAPI.py
@@ -365,7 +365,8 @@ class DuetWebAPI:
             r = self.requests.get(URL,timeout=8)
             j = self.json.loads(r.text)
             s=j['firmwareVersion']
-            if s == "3.2":
+            sArray = s.split('.')
+            if int(sArray[0]) == 3:
                 return True
             else:
                 return False


### PR DESCRIPTION
the method for checking what version of RepRapFirmware a Duet 2 was running was hardcoded to look for version 3.2 This is a small fix to split the returned firmwareVersion variable, then check against the Major revision number