### PR TITLE
Bugfix for moonraker and template API

### DIFF
--- a/drivers/API_template.py
+++ b/drivers/API_template.py
@@ -56,7 +56,7 @@ class printerAPI:
     # 
     # Raises: 
     #   - UnknownController: if fails to connect
-    def __init__( self, baseURL, nickname='Default' ):
+    def __init__( self, baseURL, nickname='Default', password='reprap' ):
         _logger.debug('Starting API..')
 
         # Here are the required class attributes. These get saved to settings.json

--- a/drivers/MoonrakerAPI.py
+++ b/drivers/MoonrakerAPI.py
@@ -64,7 +64,7 @@ class printerAPI:
     #
     # Raises:
     #   - UnknownController: if fails to connect
-    def __init__(self, baseURL, nickname='Default'):
+    def __init__(self, baseURL, nickname='Default', password=''):
         _logger.debug('Starting API..')
 
         self.session = requests.Session()


### PR DESCRIPTION
Not having a password field crashed TAMV, leaving the camera inaccessible until reboot.