### PR TITLE
Fixed Moonraker connection error

### DIFF
--- a/drivers/MoonrakerAPI.py
+++ b/drivers/MoonrakerAPI.py
@@ -64,7 +64,7 @@ class printerAPI:
     #
     # Raises:
     #   - UnknownController: if fails to connect
-    def __init__(self, baseURL, nickname='Default'):
+    def __init__(self, baseURL, nickname='Default', password='none'):
         _logger.debug('Starting API..')
 
         self.session = requests.Session()


### PR DESCRIPTION
This fixes the error: "__init__() got an unexpedted keyword argument 'password'" which occurs when connect button is pressed. Same error is reported in #56.